### PR TITLE
Add 'beware' warnings to spec/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Quota Management API
 --------------------
 
+__Beware. This specification is no longer in active maintenance and the Web Applications Working Group does not intend to maintain it further.__
+
+---
+
 This repository is for editing drafts and discussion of the
 [Quota Management API](https://w3c.github.io/quota-api/).It is based on a fork of Kinuko Yasuda's [Quota Management API repository] (https://github.com/kinu/quota-api).
 

--- a/index.html
+++ b/index.html
@@ -118,6 +118,12 @@
     </section>
 
     <section id='sotd'>
+
+      <p style="background: black; color: white; font: 900 2em serif; padding: 0.5em 1em; border: dotted yellow 0.5em; text-align: center">
+        Beware. This specification is no longer in active maintenance and the Web
+        Applications Working Group does not intend to maintain it further.
+      </p>
+
     <p>
       This document is a proposal that is being made available for public
       review in order to solicit feedback, particularly from


### PR DESCRIPTION
Cribbing from the [WebSQL spec](https://www.w3.org/TR/webdatabase/) - here's a really obnoxious warning to steer developers away from this.

(For https://github.com/w3c/quota-api/issues/12)

/cc: @annevk @chaals