### PR TITLE
Fix WebIDL grammar mistake in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,8 +398,8 @@
           interface StorageQuota {
             [SameObject]
             readonly attribute FrozenArray &lt;StorageType> supportedTypes;
-            Promise &tl;void> queryInfo(StorageType type);
-            Promise &tl;void> requestPersistentQuota([Clamp] unsigned long long newQuota);
+            Promise &lt;void> queryInfo(StorageType type);
+            Promise &lt;void> requestPersistentQuota([Clamp] unsigned long long newQuota);
           };
         </pre>
         <dl>


### PR DESCRIPTION
Correct grammar mistake to WebIDL.
* Change `&tl;` to `&lt;`